### PR TITLE
Do not extract enumeration types.

### DIFF
--- a/bin/proto-convert
+++ b/bin/proto-convert
@@ -70,7 +70,8 @@ end
 def valid_msgtype?(compiled_proto, msg_type)
   msg_types = []
   File.foreach(compiled_proto) do |line|
-    if line.include?('::Google::Protobuf::DescriptorPool.generated_pool.lookup')
+    line.strip!
+    if line.include?('::Google::Protobuf::DescriptorPool.generated_pool.lookup') && line.end_with?('.msgclass')
       extracted_msg_type = line[/"([^"]*)"/, 1].freeze
       msg_types.push(extracted_msg_type) unless extracted_msg_type.nil?
     end


### PR DESCRIPTION
- Skip enumeration types while extracting.
  - A user may erroneously use an enum type which currently doesn't support `msgclass` method.
  - Calling `msgclass` on an enum type would break the code.
  - Observed and fixed under https://github.com/iamazeem/fluent-plugin-protobuf-http/pull/13.

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>