### PR TITLE
fix: win bundler issue

### DIFF
--- a/proto-convert.gemspec
+++ b/proto-convert.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
 
   spec.executables    = ['proto-convert']
 
-  spec.add_development_dependency 'bundler', '~> 2.1', '>= 2.1.0'
+  spec.add_development_dependency 'bundler', '>= 2.1.0'
   spec.add_runtime_dependency 'google-protobuf', '~> 3.12'
 end


### PR DESCRIPTION
Failing CI workflow: https://github.com/iamazeem/proto-convert/actions/runs/27958703041/job/82733951489

```shell
Could not find compatible versions

Because the current Bundler version (4.0.14) does not satisfy bundler >= 2.1.0,
< 3.A
  and Gemfile depends on bundler >= 2.1.0, < 3.A,
  version solving has failed.

Your bundle requires a different version of Bundler than the one you're running.
Install the necessary version with `gem install bundler:2.7.2` and rerun bundler
using `bundle _2.7.2_ lock`
Error: The process 'C:\hostedtoolcache\windows\Ruby\3.3.11\x64\bin\bundle.bat' failed with exit code 6
```

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>